### PR TITLE
[MRG] Force conda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,17 @@
-name: Build and Deploy
+name: Build and Deploy (TESTING)
+
+# All commented-out lines will need to be un-commented before merging. These are currently commented
+# out for debugging and testing during the actual PR, which, obviously, involves changes to this
+# workflow itself.
 
 on:
+  # push:
+  #   branches:
+  #     - main
   push:
-    branches:
-      - main
+    branches: ['**']
+  pull_request:
+    branches: ['**']
 
 jobs:
   build:
@@ -12,24 +20,17 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set Up Python
-        uses: actions/setup-python@v4
+      - name: Create and activate conda environment
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: '3.x'
-    
-      - name: Install Pandoc
-        run: sudo apt-get update && sudo apt-get install -y pandoc
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          activate-environment: website-redesign
+          environment-file: environment.yml
 
       - name: Build Website
         run: python build.py
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
+      # - name: Deploy to GitHub Pages
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,9 @@
-name: Build and Deploy (TESTING)
-
-# All commented-out lines will need to be un-commented before merging. These are currently commented
-# out for debugging and testing during the actual PR, which, obviously, involves changes to this
-# workflow itself.
+name: Build and Deploy
 
 on:
-  # push:
-  #   branches:
-  #     - main
   push:
-    branches: ['**']
-  pull_request:
-    branches: ['**']
+    branches:
+      - main
 
 jobs:
   build:
@@ -32,8 +24,8 @@ jobs:
       - name: Build Website
         run: python build.py
 
-      # - name: Deploy to GitHub Pages
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: .
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,12 @@
 name: website-redesign
+channels:
+  - conda-forge
 dependencies:
   - python=3.12
-  - beautifulsoup4
-  - pip
-  - pypandoc
+  - beautifulsoup4==4.12.3
+  - pandoc==3.6.2
+  - pip==25.0
+  - pypandoc==1.15
+  - pip:
+    - hnn_core[dev]==0.4rc4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pypandoc
-beautifulsoup4


### PR DESCRIPTION
This does two primary things:

1. Changes all dependency/environment installation to use Conda, **including Pandoc itself**, and **including the Github Actions deployment**.
2. Sets *explicit* versions of the dependencies in the conda environment file, allowing the same file to act as a "weak" lockfile. This way, we can also be sure everyone is using the same version to build the webpages.

As far as making versions explicit, I don't think it's super important, but it may help if any two people's HTML output are different (something that I have not written down anywhere is that I think my system's post-`build.py` HTML output *may* be different from yours by default). If you don't want to make the versions explicit, that's fine with me.

As far as Conda versus pip goes, I am strongly in favor of using Conda for this repo for two reasons:
1. Conda can act as our Pandoc-binary-distribution mechanism itself, in addition to Python package management. This means that, for lab members to contribute, there is no second step needed for installing Pandoc on their machine, or an incompatible version of Pandoc, etc. Even if we don't make all package versions explicit, we should still keep Pandoc's explicit; note that Conda's default channels provide Pandoc 2.12, Ubuntu 24.04LTS provides 3.1.3, and Conda-forge provides 3.6.2 currently.
2. Eventually, this will also be important when the time comes to include MPI in the install. Some of the example notebooks will require MPI to be installed, and as discussed offline, Conda is the only cross-platform (macos and linux) way to do that.