### PR TITLE
[MRG] feat: reintroduce older "stylefig" css div class

### DIFF
--- a/content/assets/styles.css
+++ b/content/assets/styles.css
@@ -28,6 +28,13 @@ a:hover {
     color: var(--hnn-purple);
 }
 
+.stylefig {
+  text-align:center;
+  max-width:650px;
+  margin-left:auto;
+  margin-right:auto;
+}
+
 #main {
     transition: margin-left 0.5s;
     padding: 0px;


### PR DESCRIPTION
This styling is already heavily used in most other HNN tutorial files. It would be very convenient to re-introduce it just for the sake of removing boilerplate as we merge in old tutorial files.