### PR TITLE
[MRG] feat: add automatic mathml usage on conversion

### DIFF
--- a/build.py
+++ b/build.py
@@ -109,6 +109,7 @@ def generate_page_html(page_paths):
                 path,
                 to='html',
                 # format='md',
+                extra_args=["--mathml"],
             )
         except Exception as ex:
             # download Pandoc dependency if needed


### PR DESCRIPTION
Instead of Mathjax, this adds MathML rendering for equations in our Pandoc conversion process. This appears to resolve #13. 

Note that despite the warning that MathML is only supported on Firefox and Safari on Pandoc's help ( https://pandoc.org/chunkedhtml-demo/3.6-math-rendering-in-html.html ), on my MacOS, it appears to render correctly also on Chrome and Brave, so this may work for our use-case across all browsers.