### PR TITLE
[BLOCKED] Use `hnn_core[all]` for installation instructions

### DIFF
--- a/content/01_getting_started/03_installation.md
+++ b/content/01_getting_started/03_installation.md
@@ -148,7 +148,7 @@ Please follow the instructions in Steps 1, 2, and 3, *in that order*. This insta
 Note that the `pip` installation methods do *not* include all features by default, only the API. If you want to install a specific set of features, you must include all of them in your `pip` install command. For example, if you want HNN GUI support and Optimization support, but not Parallel support, then you would replace the final command in Step 3 with
 
 ```
-pip install "hnn_core[gui,opt]"
+pip install "hnn_core[all]"
 ```
 
 ## Step 1. `pip` Python Environment


### PR DESCRIPTION
@asoplata added this option in https://github.com/jonescompneurolab/hnn-core/pull/1184 and it'd be good to have it documented somewhere

Apologies I don't quite remember if this is the right protocol for updating the textbook when there's tangible changes to the code base, opening this so I don't forget the change but will reread those instructions again