### PR TITLE
[MRG] Fix dependency issue for MNE notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ clean:
 create-textbook-stable-build:
 	$(call create-and-configure-env,textbook-stable-build,false)
 	conda run -n textbook-stable-build pip install 'hnn_core[dev]==$(HNN_VERSION)'
+	conda run -n textbook-stable-build pip install --force-reinstall 'pooch==1.8.2'
 	@echo "Conda environment 'textbook-stable-build' successfully created."
 	@echo -e "\n\nActivate your environment with 'conda activate textbook-stable-build'"
 
@@ -84,6 +85,7 @@ create-textbook-dev-build:
 	LATEST_HASH=$$(git ls-remote https://github.com/jonescompneurolab/hnn-core.git master | cut -f1);
 	@# Install hnn-core in developer mode, forcing reinstall without cache
 	conda run -n textbook-dev-build pip install --upgrade --force-reinstall --no-cache-dir "hnn-core[dev] @ git+https://github.com/jonescompneurolab/hnn-core.git@master"
+	conda run -n textbook-dev-build pip install --force-reinstall 'pooch==1.8.2'
 
 	@echo "Conda environment 'textbook-dev-build' successfully created."
 	@echo -e "\n\nActivate your environment with 'conda activate textbook-dev-build'"

--- a/content/09_data_to_simulation/from_meg_to_hnn_notebook.ipynb
+++ b/content/09_data_to_simulation/from_meg_to_hnn_notebook.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: This specific notebook requires the installation of several other, non-HNN packages in order to run and plot MNE output properly. The next cell will install these packages into your Python environment automatically. "
+    "Note: This specific notebook requires the installation of several other, non-HNN packages in order to run and plot MNE output properly. If you un-comment the next cell, it will install these packages into your Python environment automatically. "
    ]
   },
   {
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q mne nibabel ipyevents \"pyvista[all]\" pyvistaqt"
+    "# %pip install -q mne nibabel ipyevents \"pyvista[all]\" pyvistaqt pooch==1.8.2"
    ]
   },
   {
@@ -548,7 +548,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "website-redesign",
+   "display_name": "textbook-stable-build",
    "language": "python",
    "name": "python3"
   },
@@ -562,7 +562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,15 @@ channels:
 dependencies:
   - python=3.12
   - beautifulsoup4==4.12.3
+  - ipyevents
+  - markdown=3.4
+  - mne
+  - mpi4py
+  - nibabel
+  - openmpi>5
   - pandoc==3.6.2
   - pip==25.0
-  - pooch<1.9.0
+  - pooch==1.8.2
   - pypandoc==1.15
-  - markdown=3.4
-  - openmpi>5
-  - mpi4py
+  - pyvista[all]
+  - pyvistaqt


### PR DESCRIPTION
Okay. After much debugging, this (hopefully) fixes current issues we are having executing the MNE notebook
`content/09_data_to_simulation/from_meg_to_hnn_notebook.ipynb` in our site deployment.

The main problem is that we require a particular dependency to be at (or below) a certain version. However, for this notebook in particular, there were three places where `pip` seemed to be getting confused and accidentally installing the wrong version after it had previously installed the right version:

1. In `Makefile`, during the initial use of `environment.yml`
2. In `Makefile`, during the later `conda run ... pip install ...` step to install HNN (this step in particular is probably the culprit)
3. This notebook itself had *unique* commands that would do its own pip install from inside the notebook, again potentially updating the `pooch` version when we didn't want it to.

In the first two cases, I have forced the correct version that we need of pooch to always be installed, and installed last using `--force-reinstall`. For the third case, I've kept the cell code present for users, but commented out the kernel-level install from the notebook (along with a note), and shifted the packages that the cell installs directly into `environment.yml`.

This should finally resolve the issue and allow this notebook to be successfully executed and deployed on our `main` deploy branch of the Textbook.