### PR TITLE
[MRG] textbook expand workflow for nb section insertion

### DIFF
--- a/scripts/execute_and_convert_nbs.py
+++ b/scripts/execute_and_convert_nbs.py
@@ -146,78 +146,90 @@ def _convert_nb_html_to_json(
 
     return contents
 
+def _get_section_outputs(nb_outputs, section_header):
+    items = list(nb_outputs.items())
+
+    # locate target section
+    start_idx = None
+    for i, (title, data) in enumerate(items):
+        if title == section_header:
+            start_idx = i
+            break
+
+    if start_idx is None:
+        raise KeyError(f"Section not found: {section_header}")
+
+    start_level = items[start_idx][1]["level"]
+
+    # collect until boundary
+    result = {}
+
+    for title, data in items[start_idx:]:
+        level = data["level"]
+
+        # stop if we hit a new section that is same-or-higher level
+        if title != section_header and level <= start_level:
+            break
+
+        result[title] = data
+
+    return result
 
 def _structure_json(contents):
     """
-    (Unused) Determine the hierarchy of sections based on levels without adding content.
+    Build hierarchical structure of sections from a flat section dict.
 
-    Returns a list of sections in order of their hierarchy.
-
-    TODO This is currently unused and will be expanded in future updates.
+    contents format:
+        {
+            section_title: {"level": int, "html": str},
+            ...
+        }
     """
+
+    # IMPORTANT: dict order matters for hierarchy
+    items = list(contents.items())
+
     hierarchy = {}
+    parent_stack = []
 
-    for filename, sections in contents.items():
-        hierarchy[filename] = {}
+    for section_title, section_data in items:
+        level = section_data["level"]
+        html_contents = section_data["html"]
 
-        # list to track parent sections for potential nesting
-        parent_stack = []
+        section_info = {
+            "title": section_title,
+            "level": level,
+            "html": html_contents,
+            "sub-sections": [],
+        }
 
-        for section_title, section_data in sections.items():
-            level = section_data["level"]
-            html_contents = section_data["html"]
+        # find correct parent based on level
+        while parent_stack and parent_stack[-1]["level"] >= level:
+            parent_stack.pop()
 
-            # Create a section dict with 'title', 'level', and 'sub-sections'
-            section_info = {
-                "title": section_title,
-                "level": level,
-                "html": html_contents,
-                "sub-sections": [],
-            }
+        if parent_stack:
+            parent_stack[-1]["sub-sections"].append(section_info)
+        else:
+            hierarchy[section_title] = section_info
 
-            # Ensure only sections with a level greater than the current
-            # section remain in the stack as potential parents
-            while parent_stack and parent_stack[-1]["level"] >= level:
-                parent_stack.pop()
+        parent_stack.append(section_info)
 
-            if parent_stack:
-                # Add the section as a child of the last parent
-                parent_stack[-1]["sub-sections"].append(section_info)
-            else:
-                # Add the section as a top-level section
-                hierarchy[filename][section_title] = section_info
+    def remove_blank_subsections(section):
+        if isinstance(section, dict):
+            subs = section.get("sub-sections")
 
-            # Add the current section to the parent stack for future nesting
-            parent_stack.append(section_info)
-
-    def remove_blank_subsections(sections):
-        seek = "sub-sections"
-
-        for k, v in list(sections.items()):
-            if isinstance(v, dict):
-                # check for 'sub-sections' key in dict
-                if seek in v:
-                    # delete empty sub-sections
-                    if v[seek] == []:
-                        del v[seek]
-
-                    # Recursively check all sub-sections
-                    else:
-                        for sub_section in v[seek]:
-                            remove_blank_subsections(sub_section)
-
-            elif isinstance(v, list):
-                # if v is an empty list, delete it
-                if v == []:
-                    del sections[k]
-                # if v is a list of dicts, iterate through the dicts
+            if subs is not None:
+                if not subs:
+                    del section["sub-sections"]
                 else:
-                    for dictionary in v:
-                        remove_blank_subsections(dictionary)
+                    for sub in subs:
+                        remove_blank_subsections(sub)
 
-        return sections
+        elif isinstance(section, list):
+            for item in section:
+                remove_blank_subsections(item)
 
-    hierarchy[filename] = remove_blank_subsections(hierarchy[filename])
+    remove_blank_subsections(hierarchy)
 
     return hierarchy
 
@@ -1356,8 +1368,14 @@ def execute_and_convert_nbs_to_json(
     """
     # Setup
     # ----------------------------------------------------------------------------------
-    # Get all notebook file paths
-    all_nb_paths = sorted(content_path.glob("**/*.ipynb"))
+    # #################### [BUGFIX] DSD ####################
+    # Get all notebook file paths, excluding .ipynb checkpoint files
+    all_nb_paths = sorted(
+        path
+        for path in content_path.glob("**/*.ipynb")
+        if ".ipynb_checkpoints" not in path.parts
+    )
+    # #################### [END BUGFIX] ####################
 
     # get nb hashes from json
     nb_hashes = _load_nb_hashes(nb_hashes_path)

--- a/scripts/generate_page_html.py
+++ b/scripts/generate_page_html.py
@@ -1,18 +1,22 @@
-from copy import deepcopy
-from pathlib import Path
 import re
 import textwrap
+from copy import deepcopy
+from pathlib import Path
 
 import pypandoc
 
+from .create_indices import create_flat_index, create_hier_index
 from .create_sidebar_html import create_sidebar_html
-from .create_indices import create_hier_index, create_flat_index
-from .execute_and_convert_nbs import load_nb_json_output
+from .execute_and_convert_nbs import (
+    _get_section_outputs,
+    load_nb_json_output,
+)
 
 
 def _read_nb_json_output_html_contents(
     nb_path,
     nb_json_output_dir,
+    section_header=None,
 ):
     """
     Get the HTML output from the JSON output file of a notebook.
@@ -34,18 +38,30 @@ def _read_nb_json_output_html_contents(
     # Has content if the file is found, otherwise returns None
     nb_outputs_if_any = load_nb_json_output(nb_path, nb_json_output_dir)
     if nb_outputs_if_any:
-        nb_outputs = nb_outputs_if_any.get(nb_path.name, {})
+        full_nb_outputs = nb_outputs_if_any.get(nb_path.name, {})
         agg_html = ""
+        if section_header is not None:
+            section_nb_outputs = _get_section_outputs(
+                full_nb_outputs,
+                section_header,
+            )
+            nb_outputs = section_nb_outputs
+        else:
+            nb_outputs = full_nb_outputs
         for section, content in nb_outputs.items():
             if isinstance(content, dict) and "html" in content:
                 agg_html += content["html"]
         return agg_html
+
     else:
+        # bugfix nb_path -> nb_json_output_dir
+        # otherwise, the error when the json is not found will point to the
+        # content directory when doing a dev build, which is misleadig
         raise FileNotFoundError(
-            f"The notebook at '{nb_path}' does not appear to have a corresponding "
-            "JSON output file. Please restart the build process with one of the "
-            "execution types enabled, in order to execute the notebook. Exiting build "
-            "process."
+            f"The notebook at '{nb_json_output_dir}' does not appear to have a "
+            "corresponding JSON output file. Please restart the build process with one "
+            "of the execution types enabled, in order to execute the notebook. Exiting "
+            "build process."
         )
 
 
@@ -181,6 +197,7 @@ def _add_nb_to_html(
     # a single closing bracket, as additional parameters may be
     # included in the notebook specification line
     nb_match_pattern = re.compile(r"\[\[(.+?\.ipynb)\]")
+
     # notebook specifications with additional arguments will
     # match the exact pattern ".ipynb][" as defined below
     nb_arguments_pattern = ".ipynb]["
@@ -217,18 +234,27 @@ def _add_nb_to_html(
         nb_button_indent,
     )
 
+    # track if the notebook download button has been added
+    # notes:
+    #   prevents adding the button multiple times in the case
+    #   that multiple notebook slices are added to a single page
+    #   we currently only support have a download button for a
+    #   *single* notebook, but this could be expanded
+    nb_download_btn_added = False
+
     output_lines = []
     for line in converted_html.splitlines():
         match = nb_match_pattern.search(line)
         args = nb_arguments_pattern in line
 
-        if match and args:
-            nb_name = match.group(1)
-            nb_path = input_dir_path / nb_name
-            print(f"nb with args found: {line}")
-            print("Argument handling will be added in a future update")
-            output_lines.append(line)
-        elif match:
+        if args is not False:
+            # match the rest of the line after ".ipynb["
+            arg_match_pattern = re.compile(r"\[\[[^\]]+\]\[([^\]]+)\]\]")
+            section = arg_match_pattern.search(line).group(1)
+        else:
+            section = None
+
+        if match:
             nb_name = match.group(1)
             nb_path = input_dir_path / nb_name
 
@@ -237,12 +263,14 @@ def _add_nb_to_html(
                 "notebook_name",
                 nb_name,
             )
-            output_lines.append(
-                nb_button,
-            )
+
+            if not nb_download_btn_added:
+                output_lines = [nb_button] + output_lines
+                nb_download_btn_added = True
+
             # generate and append the nb html output
             # --------------------------------------
-            # Ugh, if we're doing a "dev" build, then we need to load the "dev" version
+            # if we're doing a "dev" build, then we need to load the "dev" version
             # of the notebook's JSON output file. For this, we need to reconstruct that
             # location:
             if is_dev_build:
@@ -251,7 +279,11 @@ def _add_nb_to_html(
             else:
                 nb_json_output_dir = nb_path.parents[0]
 
-            nb_html = _read_nb_json_output_html_contents(nb_path, nb_json_output_dir)
+            nb_html = _read_nb_json_output_html_contents(
+                nb_path,
+                nb_json_output_dir,
+                section,
+            )
             output_lines.append(nb_html)
         else:
             # This line is very important! This is where most of the md-page content
@@ -453,6 +485,7 @@ def generate_page_html(
             format="md",
             to="html",
             extra_args=[
+                "--wrap=none",
                 "--bibliography=textbook-bibliography.bib",
                 "--citeproc",
                 "--mathml",


### PR DESCRIPTION
Expand textbook workflow to handle inserting slices of .ipynb into html pages via the following format in .md files:
```
<!--
# Title: 4.2 ERP Tutorial: Getting Started
# Updated: 2026-07-13
#
# Contributors:
    # ...
-->

# Getting Started with the HNN GUI

# format: [[notebook.ipynb][header in .ipynb file]
[[erp_api_walkthrough.ipynb][Getting Started with the HNN Python API]]
# everything under the header "Getting Started with the HNN Python API" will be added to this html page
```

My example of this in action for the ERP tutorial is also in this PR; we can either merge that with the code changes or separate the ERP tutorial into its own PR once all of the code changes we need have been identified / made